### PR TITLE
Docs: add contributing guidelines to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+## Contributing
+
+We welcome contributions from the community. This project follows standard
+open-source contribution practices under the OWASP Foundation.
+
+### How to Contribute
+1. Fork this repository to your GitHub account.
+2. Clone your fork to your local machine.
+3. Create a new branch for your changes.
+4. Make your updates or improvements.
+5. Commit and push your changes.
+6. Open a Pull Request against the `main` branch.
+
+### Good First Contributions
+- Documentation improvements
+- Fixing typos or broken links
+- Improving clarity of existing pages
+- Enhancing onboarding information for new contributors
+
+## Google Summer of Code
+
+OWASP BLT participates in Google Summer of Code as part of the OWASP organisation.
+Students interested in applying to future GSoC editions are encouraged to start
+contributing early and engage with the community through issues and pull requests.
+


### PR DESCRIPTION
This PR adds a Contributing section to the README to help new contributors
understand the standard workflow and get started with the project.
