### PR TITLE
docs: fix broken roadmap link in index.md

### DIFF
--- a/index.md
+++ b/index.md
@@ -67,7 +67,7 @@ View all contributors: [https://github.com/OWASP-BLT/BLT/graphs/contributors](ht
 
 # Roadmap
 
-View the project roadmap: [https://github.com/orgs/OWASP-BLT/projects/2/views/5](https://github.com/orgs/OWASP-BLT/projects/2/views/5)
+View the project roadmap: [https://github.com/orgs/OWASP-BLT/projects/2/views/2](https://github.com/orgs/OWASP-BLT/projects/2/views/2)
 
 ---
 


### PR DESCRIPTION
The previous link to /views/5 returned 'This view no longer exists'. Updated to the correct view /views/2 which is currently active and accessible.

## ✅ Verification
- [x] Confirmed old link shows "This view no longer exists"
- [x] Verified new link works and displays the active project roadmap
- [x] No other links in the file need updating
## 🏷️ Type of Change
- [x] Documentation fix
- [x] Bug fix (broken link)